### PR TITLE
Add OSF v0.5 grammar, schema and API

### DIFF
--- a/spec/v0.5/grammar.ebnf
+++ b/spec/v0.5/grammar.ebnf
@@ -1,0 +1,36 @@
+# OSF v0.5 EBNF Grammar
+
+Document   = { S Block } ;
+
+Block      = MetaBlock | DocBlock | SlideBlock | SheetBlock ;
+
+MetaBlock  = "@meta" S "{" S { MetaEntry } "}" ;
+MetaEntry  = Identifier S ":" S Value S ";" S ;
+
+DocBlock   = "@doc" S "{" DocContent "}" ;
+DocContent = { ~"}" } ;
+
+SlideBlock = "@slide" S "{" S { SlideEntry } "}" ;
+SlideEntry = Bullets | (Identifier S ":" S Value S ";" S) ;
+Bullets    = "bullets" S "{" S { String S ";" S } "}" ;
+
+SheetBlock = "@sheet" S "{" S { SheetEntry } "}" ;
+SheetEntry = DataBlock | FormulaLine | (Identifier S ":" S Value S ";" S) ;
+DataBlock  = "data" S "{" S { CellAssign } "}" ;
+CellAssign = "(" Number "," Number ")" S "=" S Value S ";" S ;
+FormulaLine= "formula" S "(" Number "," Number ")" S ":" S String S ";" S ;
+
+Value      = String | Number | Boolean | Identifier | Array | Object ;
+Array      = "[" S [ Value { S "," S Value } ] S "]" ;
+Object     = "{" S { Identifier S ":" S Value S ";" S } "}" ;
+Identifier = Letter { Letter | Digit | "_" | "%" } ;
+String     = '"' { Character - '"' } '"' ;
+Number     = Digit { Digit } [ "." Digit { Digit } ] ;
+Boolean    = "true" | "false" ;
+
+S          = { Whitespace | Comment } ;
+Whitespace = " " | "\t" | "\n" | "\r" ;
+Comment    = "//" { Character - "\n" } "\n" ;
+Letter     = "A".."Z" | "a".."z" ;
+Digit      = "0".."9" ;
+Character  = ? any Unicode character ? ;

--- a/spec/v0.5/osf.openapi.yaml
+++ b/spec/v0.5/osf.openapi.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: OSF Service
+  version: 0.5.0
+paths:
+  /parse:
+    post:
+      summary: Parse an OSF document
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: Parsed representation
+          content:
+            application/json:
+              schema:
+                $ref: './osf.schema.json'
+  /render:
+    post:
+      summary: Render an OSF document to a target format
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                osf:
+                  type: string
+                format:
+                  type: string
+                  enum: [html, pdf, docx, pptx, xlsx]
+              required: [osf, format]
+      responses:
+        '200':
+          description: Rendered output
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary

--- a/spec/v0.5/osf.schema.json
+++ b/spec/v0.5/osf.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OmniScript Format v0.5",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "title": { "type": "string" },
+        "author": { "type": "string" },
+        "date": { "type": "string", "format": "date" },
+        "theme": { "type": "string" }
+      }
+    },
+    "docs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "content": { "type": "string" }
+        },
+        "required": ["content"]
+      }
+    },
+    "slides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "layout": { "type": "string" },
+          "bullets": { "type": "array", "items": { "type": "string" } },
+          "notes": { "type": "string" },
+          "image": { "type": "string" }
+        },
+        "required": ["title"]
+      }
+    },
+    "sheets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "cols": { "type": "array", "items": { "type": "string" } },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "row": { "type": "integer" },
+                "col": { "type": "integer" },
+                "value": {}
+              },
+              "required": ["row", "col", "value"]
+            }
+          },
+          "formulas": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "row": { "type": "integer" },
+                "col": { "type": "integer" },
+                "expr": { "type": "string" }
+              },
+              "required": ["row", "col", "expr"]
+            }
+          }
+        },
+        "required": ["name"]
+      }
+    }
+  },
+  "required": ["meta"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- define complete EBNF grammar for OSF v0.5
- add JSON Schema describing OSF structure
- provide OpenAPI specification with parse and render endpoints

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854044e6b60832bb5e7d8d27f025d02