### PR TITLE
Implement basic parser and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ omniscript-core/
 * `osf export <file> --target <format>` → Export OSF to target format preserving fidelity.
 * `osf format <file>` → Auto-format OSF for style consistency.
 
+### Using the reference CLI
+
+After compiling the project (`npm test`), invoke the CLI to parse a document:
+
+```bash
+node cli/bin/osf.js parse examples/test_minimal.osf
+```
+
 ---
 
 ## 🤝 Contributing

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -1,1 +1,1 @@
-import './osf-parse';
+import './osf';

--- a/cli/src/osf-diff.ts
+++ b/cli/src/osf-diff.ts
@@ -1,1 +1,0 @@
-console.log('diff not implemented');

--- a/cli/src/osf-lint.ts
+++ b/cli/src/osf-lint.ts
@@ -1,1 +1,0 @@
-console.log('lint not implemented');

--- a/cli/src/osf-parse.ts
+++ b/cli/src/osf-parse.ts
@@ -1,7 +1,0 @@
-import { readFileSync } from 'fs';
-import { parse } from '../../parser/src';
-
-const file = process.argv[2];
-const text = readFileSync(file, 'utf8');
-const doc = parse(text);
-console.log(JSON.stringify(doc, null, 2));

--- a/cli/src/osf-render.ts
+++ b/cli/src/osf-render.ts
@@ -1,1 +1,0 @@
-console.log('render not implemented');

--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'fs';
+import { parse } from '../../parser/dist';
+
+function load(file: string): string {
+  return readFileSync(file, 'utf8');
+}
+
+const [, , command, ...rest] = process.argv;
+
+switch (command) {
+  case 'parse': {
+    const text = load(rest[0]);
+    const doc = parse(text);
+    console.log(JSON.stringify(doc, null, 2));
+    break;
+  }
+  case 'lint': {
+    try {
+      parse(load(rest[0]));
+      console.log('OK');
+    } catch (err: any) {
+      console.error(`Lint error: ${err.message}`);
+      process.exit(1);
+    }
+    break;
+  }
+  case 'diff': {
+    const docA = parse(load(rest[0]));
+    const docB = parse(load(rest[1]));
+    const same = JSON.stringify(docA) === JSON.stringify(docB);
+    console.log(same ? 'No differences' : 'Documents differ');
+    if (!same) process.exit(1);
+    break;
+  }
+  default:
+    console.log('Usage: osf <parse|lint|diff> <files...>');
+}

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -1,1 +1,8 @@
-console.log('cli tests placeholder');
+const { execFileSync } = require('child_process');
+const path = require('path');
+const file = path.resolve(__dirname, '../../examples/test_minimal.osf');
+const out = execFileSync('node', [require.resolve('../bin/osf.js'), 'parse', file], { encoding: 'utf8' });
+const result = JSON.parse(out);
+if (!Array.isArray(result.blocks)) {
+  throw new Error('parse failed');
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -5,5 +5,7 @@
     "target": "es2019",
     "module": "commonjs",
     "declaration": true
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["tests"]
 }

--- a/examples/test_minimal.osf
+++ b/examples/test_minimal.osf
@@ -1,3 +1,26 @@
+@meta {
+  title: "Demo";
+  author: "Test";
+}
+
 @doc {
   Hello World
+}
+
+@slide {
+  title: "Intro";
+  bullets {
+    "First";
+    "Second";
+  }
+}
+
+@sheet {
+  name: "Data";
+  cols: [A, B];
+  data {
+    (2,1)=1;
+    (2,2)=2;
+  }
+  formula (2,2): "=A1";
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "workspaces": ["parser", "cli"],
   "scripts": {
-    "pretest": "npx tsc -p parser/tsconfig.json",
-    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js"
+    "pretest": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
+    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/parser/src/index.ts
+++ b/parser/src/index.ts
@@ -1,2 +1,2 @@
-export { parse } from './parser';
-export { serialize } from './serializer';
+export { parse, serialize } from './parser';
+export * from './types';

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -1,10 +1,140 @@
-import { tokenize, Token } from './lexer';
+import { OSFDocument, OSFBlock, MetaBlock, DocBlock, SlideBlock, SheetBlock } from './types';
 
-export interface OSFDocument {
-  lines: string[];
+function findBlocks(input: string): { type: string; content: string }[] {
+  const blocks: { type: string; content: string }[] = [];
+  const regex = /@(\w+)\s*\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(input))) {
+    const type = match[1];
+    let depth = 1;
+    let end = match.index + match[0].length;
+    while (end < input.length && depth > 0) {
+      const ch = input[end];
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+      end++;
+    }
+    const content = input.slice(match.index + match[0].length, end - 1);
+    blocks.push({ type, content: content.trim() });
+  }
+  return blocks;
+}
+
+function parseKV(content: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const kvRegex = /(\w+)\s*:\s*([^;]+);/g;
+  let m: RegExpExecArray | null;
+  while ((m = kvRegex.exec(content))) {
+    let value: any = m[2].trim();
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    } else if (!isNaN(Number(value))) {
+      value = Number(value);
+    }
+    result[m[1]] = value;
+  }
+  return result;
 }
 
 export function parse(input: string): OSFDocument {
-  const tokens: Token[] = tokenize(input);
-  return { lines: tokens.map(t => t.value) };
+  const blocksRaw = findBlocks(input);
+  const blocks: OSFBlock[] = blocksRaw.map(b => {
+    switch (b.type) {
+      case 'meta':
+        const props = parseKV(b.content);
+        return { type: 'meta', props } as MetaBlock;
+      case 'doc':
+        return { type: 'doc', content: b.content } as DocBlock;
+      case 'slide':
+        const slide: SlideBlock = { type: 'slide' };
+        const bulletMatch = /bullets\s*\{([\s\S]*?)\}/.exec(b.content);
+        if (bulletMatch) {
+          const items = bulletMatch[1].split(/;\s*/).map(s => s.trim()).filter(Boolean);
+          slide.bullets = items.map(it => it.replace(/^"|"$/g, ''));
+        }
+        const rest = b.content.replace(/bullets\s*\{[\s\S]*?\}/, '');
+        Object.assign(slide, parseKV(rest));
+        return slide;
+      case 'sheet':
+        const sheet: SheetBlock = { type: 'sheet', data: {}, formulas: [] };
+        const dataMatch = /data\s*\{([\s\S]*?)\}/.exec(b.content);
+        if (dataMatch) {
+          const assigns = dataMatch[1].split(/;\s*/).map(s => s.trim()).filter(Boolean);
+          for (const a of assigns) {
+            const m = /^\((\d+),(\d+)\)\s*=\s*(.+)$/.exec(a);
+            if (m) {
+              const key = `${m[1]},${m[2]}`;
+              let val: any = m[3];
+              if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+              else if (!isNaN(Number(val))) val = Number(val);
+              sheet.data![key] = val;
+            }
+          }
+        }
+        const formulaRegex = /formula\s*\((\d+),(\d+)\)\s*:\s*"([^"]*)";/g;
+        let fm: RegExpExecArray | null;
+        while ((fm = formulaRegex.exec(b.content))) {
+          sheet.formulas!.push({ cell: [Number(fm[1]), Number(fm[2])], expr: fm[3] });
+        }
+        const restSheet = b.content
+          .replace(/data\s*\{[\s\S]*?\}/, '')
+          .replace(formulaRegex, '');
+        Object.assign(sheet, parseKV(restSheet));
+        return sheet;
+      default:
+        return { type: 'doc', content: b.content } as DocBlock;
+    }
+  });
+  return { blocks };
+}
+
+export function serialize(doc: OSFDocument): string {
+  return doc.blocks
+    .map(b => {
+      switch (b.type) {
+        case 'meta':
+          const entries = Object.entries(b.props)
+            .map(([k, v]) => `${k}: ${typeof v === 'string' ? '"' + v + '"' : v};`)
+            .join(' ');
+          return `@meta {\n  ${entries}\n}`;
+        case 'doc':
+          return `@doc {\n${b.content}\n}`;
+        case 'slide':
+          const bulletStr = b.bullets && b.bullets.length
+            ? `bullets {\n    ${b.bullets.map(i => '"' + i + '";').join(' ')}\n  }\n`
+            : '';
+          const other = { ...b } as any;
+          delete other.type;
+          delete other.bullets;
+          const kv = Object.entries(other)
+            .map(([k, v]) => `${k}: ${typeof v === 'string' ? '"' + v + '"' : v};`)
+            .join(' ');
+          return `@slide {\n  ${kv}\n  ${bulletStr}}`;
+        case 'sheet':
+          const parts: string[] = [];
+          const otherSheet = { ...b } as any;
+          delete otherSheet.type;
+          const dataObj = otherSheet.data; delete otherSheet.data;
+          const formulas = otherSheet.formulas; delete otherSheet.formulas;
+          const kvs = Object.entries(otherSheet)
+            .map(([k, v]) => `${k}: ${Array.isArray(v) ? `[${(v as any[]).join(', ')}]` : (typeof v === 'string' ? '"' + v + '"' : v)};`)
+            .join(' ');
+          if (kvs) parts.push(kvs);
+          if (dataObj && Object.keys(dataObj).length) {
+            const rows = Object.entries(dataObj)
+              .map(([cell, val]) => `(${cell})=${typeof val === 'string' ? '"' + val + '"' : val};`)
+              .join(' ');
+            parts.push(`data {\n    ${rows}\n  }`);
+          }
+          if (formulas && formulas.length) {
+            for (const f of formulas) {
+              parts.push(`formula (${f.cell[0]},${f.cell[1]}): "${f.expr}";`);
+            }
+          }
+          return `@sheet {\n  ${parts.join('\n  ')}\n}`;
+        default:
+          return '';
+      }
+    })
+    .join('\n\n');
 }

--- a/parser/src/serializer.ts
+++ b/parser/src/serializer.ts
@@ -1,5 +1,0 @@
-import { OSFDocument } from './parser';
-
-export function serialize(doc: OSFDocument): string {
-  return doc.lines.join('\n');
-}

--- a/parser/src/types.ts
+++ b/parser/src/types.ts
@@ -1,0 +1,32 @@
+export interface MetaBlock {
+  type: 'meta';
+  props: Record<string, any>;
+}
+
+export interface DocBlock {
+  type: 'doc';
+  content: string;
+}
+
+export interface SlideBlock {
+  type: 'slide';
+  title?: string;
+  layout?: string;
+  bullets?: string[];
+  [key: string]: any;
+}
+
+export interface SheetBlock {
+  type: 'sheet';
+  name?: string;
+  cols?: string[];
+  data?: Record<string, any>;
+  formulas?: { cell: [number, number]; expr: string }[];
+  [key: string]: any;
+}
+
+export type OSFBlock = MetaBlock | DocBlock | SlideBlock | SheetBlock;
+
+export interface OSFDocument {
+  blocks: OSFBlock[];
+}

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -1,14 +1,19 @@
 # OmniScript Format Roadmap
 
-This document outlines planned milestones and accepted proposals for future releases of the OmniScript Format.
+This roadmap highlights the short‑term milestones for the OSF project. It is derived from the OSF v0.5 specification and focuses on delivering a minimal but complete toolchain for authoring documents, slides and sheets in plain text.
 
 ## v1.0 Goals
-- Finalize core syntax for documents, slides and sheets.
-- Provide reference parser and CLI tooling.
-- Ensure round‑trip conversion with common formats.
+
+- **Finalize core block syntax** – stable `@meta`, `@doc`, `@slide` and `@sheet` sections as described in [spec/v0.5/osf-spec.md](v0.5/osf-spec.md).
+- **Reference parser** – ability to parse an `.osf` file into an AST matching the JSON schema.
+- **Command line tooling** – `osf` CLI providing `parse`, `lint`, `diff` and `render` commands.
+- **Round‑trip conversion** – lossless serialisation back to the text form.
+- **Examples and documentation** – minimal examples demonstrating each block type.
 
 ## v1.1 Ideas
-- Expanded chart and shape support.
-- Basic citation syntax.
 
-Proposals are tracked in the repository issues and discussion forum.
+- Chart and diagram primitives for slides and sheets.
+- Basic citation and cross‑reference syntax.
+- Import/export helpers for Markdown, LaTeX and Office formats.
+
+Community proposals are tracked in repository issues and the discussion forum.

--- a/tests/fixtures/expected_output.json
+++ b/tests/fixtures/expected_output.json
@@ -1,1 +1,1 @@
-{"lines":["@doc {Test}",""]}
+{"blocks":[{"type":"doc","content":"Test"}]}


### PR DESCRIPTION
## Summary
- flesh out OSF roadmap
- implement parser with support for meta/doc/slide/sheet blocks
- implement simple CLI (`osf`) with parse/lint/diff commands
- update examples and README
- adjust tests for new parser and CLI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685406baa92c832b817ce74f2a19d00b