### PR TITLE
Add CLI commands per v0.5 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,15 @@ omniscript-core/
 
 ---
 
-## 🚀 Planned CLI Features
+## 🚀 CLI Features
+
+The reference CLI implements several spec-defined commands:
 
 * `osf parse <file>` → Parse and validate OSF file syntax.
 * `osf lint <file>` → Style and structure checks.
-* `osf render <file> --format <html|pdf|docx|pptx|xlsx>` → Render to desired output.
 * `osf diff <file1> <file2>` → Semantic diff of two OSF files.
-* `osf export <file> --target <format>` → Export OSF to target format preserving fidelity.
+* `osf render <file> --format <html>` → Render to HTML output.
+* `osf export <file> --target <md>` → Export OSF to Markdown.
 * `osf format <file>` → Auto-format OSF for style consistency.
 
 ### Using the reference CLI

--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,5 +1,82 @@
 import { readFileSync } from 'fs';
-import { parse } from '../../parser/dist';
+import { parse, serialize, OSFDocument, OSFBlock } from '../../parser/dist';
+
+function renderHtml(doc: OSFDocument): string {
+  const parts: string[] = ['<html><body>'];
+  for (const block of doc.blocks) {
+    switch (block.type) {
+      case 'doc':
+        parts.push(`<p>${(block as any).content}</p>`);
+        break;
+      case 'slide':
+        parts.push('<section class="slide">');
+        if ((block as any).title) {
+          parts.push(`<h2>${(block as any).title}</h2>`);
+        }
+        if ((block as any).bullets) {
+          parts.push('<ul>');
+          for (const b of (block as any).bullets) {
+            parts.push(`<li>${b}</li>`);
+          }
+          parts.push('</ul>');
+        }
+        parts.push('</section>');
+        break;
+      case 'sheet':
+        const sheet = block as any;
+        parts.push('<table>');
+        if (sheet.cols) {
+          const cols = Array.isArray(sheet.cols)
+            ? sheet.cols
+            : String(sheet.cols)
+                .replace(/[\[\]]/g, '')
+                .split(',')
+                .map((s: string) => s.trim());
+          parts.push('<tr>' + cols.map((c: string) => `<th>${c}</th>`).join('') + '</tr>');
+        }
+        if (sheet.data) {
+          const rows: Record<string, any> = sheet.data;
+          const coords = Object.keys(rows).map(k => k.split(',').map(Number));
+          const maxRow = Math.max(...coords.map(c => c[0]));
+          const maxCol = Math.max(...coords.map(c => c[1]));
+          for (let r = 1; r <= maxRow; r++) {
+            parts.push('<tr>');
+            for (let c = 1; c <= maxCol; c++) {
+              const key = `${r},${c}`;
+              const val = rows[key] ?? '';
+              parts.push(`<td>${val}</td>`);
+            }
+            parts.push('</tr>');
+          }
+        }
+        parts.push('</table>');
+        break;
+    }
+  }
+  parts.push('</body></html>');
+  return parts.join('');
+}
+
+function exportMarkdown(doc: OSFDocument): string {
+  const out: string[] = [];
+  for (const block of doc.blocks) {
+    switch (block.type) {
+      case 'doc':
+        out.push((block as any).content);
+        break;
+      case 'slide':
+        if ((block as any).title) out.push('## ' + (block as any).title);
+        if ((block as any).bullets) {
+          for (const b of (block as any).bullets) {
+            out.push('- ' + b);
+          }
+        }
+        out.push('');
+        break;
+    }
+  }
+  return out.join('\n');
+}
 
 function load(file: string): string {
   return readFileSync(file, 'utf8');
@@ -32,6 +109,38 @@ switch (command) {
     if (!same) process.exit(1);
     break;
   }
+  case 'render': {
+    const file = rest[0];
+    const formatFlag = rest.indexOf('--format');
+    const fmt = formatFlag >= 0 ? rest[formatFlag + 1] : 'html';
+    const doc = parse(load(file));
+    if (fmt === 'html') {
+      console.log(renderHtml(doc));
+    } else {
+      console.error(`Unknown format: ${fmt}`);
+      process.exit(1);
+    }
+    break;
+  }
+  case 'export': {
+    const file = rest[0];
+    const targetFlag = rest.indexOf('--target');
+    const target = targetFlag >= 0 ? rest[targetFlag + 1] : 'md';
+    const doc = parse(load(file));
+    if (target === 'md') {
+      console.log(exportMarkdown(doc));
+    } else {
+      console.error(`Unknown target: ${target}`);
+      process.exit(1);
+    }
+    break;
+  }
+  case 'format': {
+    const text = load(rest[0]);
+    const doc = parse(text);
+    console.log(serialize(doc));
+    break;
+  }
   default:
-    console.log('Usage: osf <parse|lint|diff> <files...>');
+    console.log('Usage: osf <parse|lint|diff|render|export|format> <file>');
 }

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -1,8 +1,23 @@
 const { execFileSync } = require('child_process');
 const path = require('path');
 const file = path.resolve(__dirname, '../../examples/test_minimal.osf');
-const out = execFileSync('node', [require.resolve('../bin/osf.js'), 'parse', file], { encoding: 'utf8' });
-const result = JSON.parse(out);
+const cli = require.resolve('../bin/osf.js');
+
+// parse
+const parseOut = execFileSync('node', [cli, 'parse', file], { encoding: 'utf8' });
+const result = JSON.parse(parseOut);
 if (!Array.isArray(result.blocks)) {
   throw new Error('parse failed');
+}
+
+// format
+const fmt = execFileSync('node', [cli, 'format', file], { encoding: 'utf8' });
+if (!fmt.includes('@doc')) {
+  throw new Error('format failed');
+}
+
+// render html
+const html = execFileSync('node', [cli, 'render', file, '--format', 'html'], { encoding: 'utf8' });
+if (!html.includes('<html>')) {
+  throw new Error('render failed');
 }


### PR DESCRIPTION
## Summary
- implement `render`, `export`, and `format` commands in the CLI
- update CLI tests for new commands
- document current CLI in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540b3b80d8832ba182f17a0bd6e90a