### PR TITLE
Add v0.5 spec example and update sample files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ omniscript-core/
  │   └── roadmap.md
  ├── parser/             # Reference parser
  ├── cli/                # CLI tools
- ├── examples/           # Minimal test examples
+ ├── examples/           # OSF sample documents (spec example + tests)
  ├── tests/              # Unit + integration tests
  ├── docs/               # Architecture and design docs
  ├── .github/            # GitHub configs
@@ -98,7 +98,14 @@ omniscript-core/
 
 ### Using the reference CLI
 
-After compiling the project (`npm test`), invoke the CLI to parse a document:
+After compiling the project (`npm test`), invoke the CLI to parse a document.
+For the full spec example:
+
+```bash
+node cli/bin/osf.js parse examples/v0.5_spec_example.osf
+```
+
+Or to parse a minimal test file:
 
 ```bash
 node cli/bin/osf.js parse examples/test_minimal.osf

--- a/examples/test_sheet.osf
+++ b/examples/test_sheet.osf
@@ -1,3 +1,8 @@
+@meta {
+  title: "Sheet Example";
+  author: "Test";
+}
+
 @sheet {
   name: "Data";
   cols: [A, B];

--- a/examples/test_slides.osf
+++ b/examples/test_slides.osf
@@ -1,3 +1,8 @@
+@meta {
+  title: "Slides Example";
+  author: "Test";
+}
+
 @slide {
   title: "Intro";
   bullets {

--- a/examples/v0.5_spec_example.osf
+++ b/examples/v0.5_spec_example.osf
@@ -1,0 +1,32 @@
+@meta {
+  title: "Q2 Business Review";
+  author: "Alphin Tom";
+  date: "2025-06-07";
+  theme: "CorporateBlue";
+}
+
+@doc {
+  # Executive Summary
+  Revenue grew by **15%** in Q2, exceeding targets and prior quarter performance.
+  We continued to invest in customer success, resulting in higher retention.
+}
+
+@slide {
+  title: "Q2 Highlights";
+  layout: TitleAndBullets;
+  bullets {
+    "Revenue ↑ 15%";
+    "Churn ↓ 3%";
+  }
+}
+
+@sheet {
+  name: "SalesData";
+  cols: [Region, Q1, Q2, Growth%];
+  data {
+    (2,1) = "North";   (2,2) = 100000;   (2,3) = 115000;
+    (3,1) = "South";   (3,2) =  80000;   (3,3) =  92000;
+  }
+  formula (2,4): "=(C2-B2)/B2*100";
+  formula (3,4): "=(C3-B3)/B3*100";
+}


### PR DESCRIPTION
## Summary
- update README examples section
- add an official OSF v0.5 example file
- include `@meta` blocks in sheet and slides examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540b49bcd0832b90564125ce76b461