### PR TITLE
Update docs for OSF v0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ omniscript-core/
  └── package.json
 ```
 
+See [docs/spec-v0.5-overview.md](docs/spec-v0.5-overview.md) for an introduction to the draft specification.
+
 ---
 
 ## 🚀 Quick Example

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,15 @@
 # Project Architecture
 
-The project is organised as a monorepo with packages for the parser and CLI.
+This repository hosts the reference implementation of **OmniScript Format (OSF)**. The codebase is organised as a monorepo with separate packages for the parser and CLI.
+
+The `spec/` directory contains versioned specifications. The current draft is [spec/v0.5](../spec/v0.5/) which defines the grammar and JSON schema used by the parser.
+
+```
+omniscript-core/
+ ├── spec/       # Formal OSF specifications
+ ├── parser/     # Reference parser and serializer
+ ├── cli/        # Command line interface
+ └── docs/       # Project and design documentation
+```
+
+Developers can run the parser directly or invoke the CLI for tasks like parsing, linting and rendering OSF files. See the spec for a detailed description of each block type (`@meta`, `@doc`, `@slide`, `@sheet`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,8 @@
 # Contributing Guide
 
-Please open issues and pull requests on GitHub.
+We welcome pull requests!
+
+1. Read the OSF draft in [spec/v0.5](../spec/v0.5/) to understand the current language features.
+2. Follow the coding style used in the parser and CLI packages.
+3. Tests are located under `tests/` and `parser/tests`. Please add tests for new functionality.
+4. For larger features, check `spec/roadmap.md` or open an issue to discuss changes to the specification before implementation.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,3 +1,7 @@
 # Design Decisions
 
-Key decisions are documented here as the project evolves.
+This project follows the OSF v0.5 specification located under `spec/v0.5`. The core blocks – `@meta`, `@doc`, `@slide` and `@sheet` – are implemented as described in that draft.
+
+* **Parser simplicity** – The reference parser mirrors the grammar in `spec/v0.5/grammar.ebnf` to keep implementations easy to understand.
+* **JSON Schema** – The AST produced by the parser conforms to `spec/v0.5/osf.schema.json` which allows tooling in any language to validate documents.
+* **Incremental roadmap** – Features beyond v0.5 are tracked in `spec/roadmap.md`. Contributions should aim to match the spec before proposing extensions.

--- a/docs/spec-v0.5-overview.md
+++ b/docs/spec-v0.5-overview.md
@@ -1,0 +1,43 @@
+# OSF v0.5 Overview
+
+This document summarises the key elements of the OmniScript Format v0.5 draft. Refer to the files under `spec/v0.5/` for the authoritative specification.
+
+## Core Blocks
+
+* `@meta` – document metadata such as `title`, `author`, `date` and `theme`.
+* `@doc` – prose content written with Markdown-like syntax.
+* `@slide` – slide definitions with properties like `title`, `layout` and optional `bullets`.
+* `@sheet` – tabular data including column headers, cell assignments and formulas.
+
+Each block follows the grammar defined in `spec/v0.5/grammar.ebnf` and maps to the JSON Schema in `spec/v0.5/osf.schema.json`.
+
+## Example
+
+```osf
+@meta {
+  title: "Demo";
+  author: "Test";
+}
+
+@doc {
+  Hello World
+}
+
+@slide {
+  title: "Intro";
+  bullets {
+    "First";
+    "Second";
+  }
+}
+
+@sheet {
+  name: "Data";
+  cols: [A, B];
+  data {
+    (2,1)=1;
+    (2,2)=2;
+  }
+  formula (2,2): "=A1";
+}
+```


### PR DESCRIPTION
## Summary
- expand architecture notes and mention `spec/v0.5`
- capture design decisions around the v0.5 draft
- clarify contribution steps with spec references
- provide a short overview of the v0.5 draft spec
- link the new overview from the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540b4f82e4832b9f56305cea9fbf18