### PR TITLE
Add Ajv schema validation to CLI lint

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,5 +8,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "node ../parser/tests/parser.test.ts"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0"
   }
 }

--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,5 +1,14 @@
 import { readFileSync } from 'fs';
+import { join } from 'path';
+import Ajv from 'ajv';
 import { parse, serialize, OSFDocument, OSFBlock } from '../../parser/dist';
+
+const schema = JSON.parse(
+  readFileSync(join(__dirname, '../../spec/v0.5/osf.schema.json'), 'utf8')
+);
+const ajv = new Ajv();
+ajv.addFormat('date', /^\d{4}-\d{2}-\d{2}$/);
+const validateOsf = ajv.compile(schema);
 
 function renderHtml(doc: OSFDocument): string {
   const parts: string[] = ['<html><body>'];
@@ -78,6 +87,46 @@ function exportMarkdown(doc: OSFDocument): string {
   return out.join('\n');
 }
 
+function toSchema(doc: OSFDocument): any {
+  const out: any = { docs: [], slides: [], sheets: [] };
+  for (const block of doc.blocks) {
+    switch (block.type) {
+      case 'meta':
+        out.meta = block.props;
+        break;
+      case 'doc':
+        out.docs.push({ content: (block as any).content });
+        break;
+      case 'slide': {
+        const s: any = { ...block };
+        delete s.type;
+        out.slides.push(s);
+        break;
+      }
+      case 'sheet': {
+        const s: any = { ...block };
+        delete s.type;
+        if (s.data) {
+          s.data = Object.entries(s.data).map(([cell, value]) => {
+            const [r, c] = cell.split(',').map(Number);
+            return { row: r, col: c, value };
+          });
+        }
+        if (s.formulas) {
+          s.formulas = s.formulas.map((f: any) => ({
+            row: f.cell[0],
+            col: f.cell[1],
+            expr: f.expr,
+          }));
+        }
+        out.sheets.push(s);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
 function load(file: string): string {
   return readFileSync(file, 'utf8');
 }
@@ -93,8 +142,15 @@ switch (command) {
   }
   case 'lint': {
     try {
-      parse(load(rest[0]));
-      console.log('OK');
+      const doc = parse(load(rest[0]));
+      const obj = toSchema(doc);
+      if (!validateOsf(obj)) {
+        console.error('Lint error: schema validation failed');
+        console.error(ajv.errorsText(validateOsf.errors || undefined));
+        process.exit(1);
+      } else {
+        console.log('OK');
+      }
     } catch (err: any) {
       console.error(`Lint error: ${err.message}`);
       process.exit(1);

--- a/cli/tests/fixtures/missing_title.osf
+++ b/cli/tests/fixtures/missing_title.osf
@@ -1,0 +1,9 @@
+@meta {
+  title: "No Title Slide";
+}
+
+@slide {
+  bullets {
+    "Only bullet";
+  }
+}

--- a/cli/tests/lint.test.ts
+++ b/cli/tests/lint.test.ts
@@ -3,6 +3,7 @@ const path = require('path');
 const cli = require.resolve('../bin/osf.js');
 const valid = path.resolve(__dirname, '../../examples/test_minimal.osf');
 const invalid = path.resolve(__dirname, 'fixtures/bad.osf');
+const schemaFail = path.resolve(__dirname, 'fixtures/missing_title.osf');
 
 // lint should succeed on valid file
 const ok = execFileSync('node', [cli, 'lint', valid], { encoding: 'utf8' }).trim();
@@ -14,4 +15,10 @@ if (ok !== 'OK') {
 const bad = spawnSync('node', [cli, 'lint', invalid], { encoding: 'utf8' });
 if (bad.status === 0 || !bad.stderr.includes('Lint error')) {
   throw new Error('lint did not report error');
+}
+
+// lint should fail on schema violation
+const badSchema = spawnSync('node', [cli, 'lint', schemaFail], { encoding: 'utf8' });
+if (badSchema.status === 0 || !badSchema.stderr.includes('schema validation')) {
+  throw new Error('lint did not detect schema issue');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
     "cli": {
       "name": "@osf/cli",
       "version": "0.1.0",
+      "dependencies": {
+        "ajv": "^8.12.0"
+      },
       "bin": {
         "osf": "bin/osf.js"
       }
@@ -133,6 +136,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -157,12 +176,49 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",


### PR DESCRIPTION
## Summary
- add Ajv runtime dependency for the CLI
- compile `osf.schema.json` in the CLI
- convert parser output to schema format for validation
- validate parsed files in `lint` command
- add failing fixture for schema validation
- extend lint tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c737d7d0832b8655cc6634bcea42