### PR TITLE
Add CLI help/version flags

### DIFF
--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { join } from 'path';
 import { parse, serialize, OSFDocument, OSFBlock } from '../../parser/dist';
 
 function renderHtml(doc: OSFDocument): string {
@@ -78,11 +79,40 @@ function exportMarkdown(doc: OSFDocument): string {
   return out.join('\n');
 }
 
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+const VERSION = pkg.version;
+
+const HELP = `Usage: osf <command> [options]
+
+Commands:
+  parse <file>           Parse OSF file to JSON
+  lint <file>            Validate OSF syntax
+  diff <fileA> <fileB>   Compare two OSF files
+  render <file>          Render OSF to HTML
+  export <file>          Export OSF to Markdown
+  format <file>         Format OSF document
+
+Options:
+  -h, --help             Show this help message
+  -v, --version          Show CLI version`;
+
 function load(file: string): string {
   return readFileSync(file, 'utf8');
 }
 
-const [, , command, ...rest] = process.argv;
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+if (args.includes('--version') || args.includes('-v')) {
+  console.log(VERSION);
+  process.exit(0);
+}
+
+const [command, ...rest] = args;
 
 switch (command) {
   case 'parse': {
@@ -142,5 +172,5 @@ switch (command) {
     break;
   }
   default:
-    console.log('Usage: osf <parse|lint|diff|render|export|format> <file>');
+    console.log(HELP);
 }

--- a/cli/tests/flags.test.ts
+++ b/cli/tests/flags.test.ts
@@ -1,0 +1,28 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const cli = require.resolve('../bin/osf.js');
+const pkg = require('../package.json');
+
+// --help
+const help = execFileSync('node', [cli, '--help'], { encoding: 'utf8' });
+if (!help.includes('Usage: osf') || !help.includes('parse')) {
+  throw new Error('help output incorrect');
+}
+
+// -h alias
+const shortHelp = execFileSync('node', [cli, '-h'], { encoding: 'utf8' });
+if (!shortHelp.includes('Usage: osf')) {
+  throw new Error('-h output incorrect');
+}
+
+// --version
+const version = execFileSync('node', [cli, '--version'], { encoding: 'utf8' }).trim();
+if (version !== pkg.version) {
+  throw new Error('version output incorrect');
+}
+
+// -v alias
+const versionShort = execFileSync('node', [cli, '-v'], { encoding: 'utf8' }).trim();
+if (versionShort !== pkg.version) {
+  throw new Error('-v output incorrect');
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
     "pretest": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
-    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/error.test.ts"
+    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/error.test.ts && node cli/tests/flags.test.ts"
   },
   "devDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- support `--help`/`-h` and `--version`/`-v` in the CLI
- print usage instructions and read version from `package.json`
- add tests for the new flags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c805e078832bae299621eaa715db