### PR TITLE
Fix parser block closing

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -14,6 +14,9 @@ function findBlocks(input: string): { type: string; content: string }[] {
       else if (ch === '}') depth--;
       end++;
     }
+    if (depth > 0) {
+      throw new Error(`Missing closing } for block ${type}`);
+    }
     const content = input.slice(match.index + match[0].length, end - 1);
     blocks.push({ type, content: content.trim() });
   }

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -13,3 +13,13 @@ if (parsed.blocks[0].type !== 'meta' || parsed.blocks[0].props.tags[1] !== 'b') 
 }
 const out = serialize(parsed);
 parse(out); // should round trip without throwing
+
+let threw = false;
+try {
+  parse('@doc {\nHello');
+} catch (err) {
+  threw = /Missing closing/.test(String(err));
+}
+if (!threw) {
+  throw new Error('expected error for incomplete block');
+}


### PR DESCRIPTION
## Summary
- detect missing closing brace while locating blocks
- test parser error for incomplete blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c80a5a3c832b8af5af71f0a6e1ca