### PR TITLE
Add brace matching validation to parser

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -14,6 +14,9 @@ function findBlocks(input: string): { type: string; content: string }[] {
       else if (ch === '}') depth--;
       end++;
     }
+    if (depth !== 0) {
+      throw new Error(`Unterminated block starting with @${type}`);
+    }
     const content = input.slice(match.index + match[0].length, end - 1);
     blocks.push({ type, content: content.trim() });
   }

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -13,3 +13,16 @@ if (parsed.blocks[0].type !== 'meta' || parsed.blocks[0].props.tags[1] !== 'b') 
 }
 const out = serialize(parsed);
 parse(out); // should round trip without throwing
+
+const { readFileSync } = require('fs');
+const { join } = require('path');
+const invalid = readFileSync(join(__dirname, '../../examples/invalid_syntax.osf'), 'utf8');
+let threw = false;
+try {
+  parse(invalid);
+} catch (e) {
+  threw = true;
+}
+if (!threw) {
+  throw new Error('parser should throw on invalid syntax');
+}


### PR DESCRIPTION
## Summary
- ensure `findBlocks` detects unterminated blocks
- test invalid syntax parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c8185cc4832b84aa90ea70ef1ef4