### PR TITLE
Add automatic build via prepare script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Follow these steps to build and run the CLI:
    npm install
    ```
 
-2. **Compile the TypeScript sources**
+   Installing will automatically run the build thanks to the `prepare` script.
+
+2. **Compile the TypeScript sources** (if you need to rebuild manually)
 
    ```bash
    npm run build

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "workspaces": ["parser", "cli"],
   "scripts": {
     "build": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
+    "prepare": "npm run build",
     "pretest": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
     "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/error.test.ts"
   },


### PR DESCRIPTION
## Summary
- run the build automatically after `npm install` via a `prepare` script
- document the new build step in the CLI usage docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c81bd37c832bb25c7255f3d2aeb6