### PR TITLE
Update docs about pre-test npm install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,10 @@ npm install
 
 ### 5️⃣ Run tests
 
+Before running the test suite, make sure all dependencies are installed:
+
 ```bash
+npm install
 npm test
 # or cargo test / pytest etc., depending on the language used
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The reference CLI implements several spec-defined commands:
 ### Using the reference CLI
 Follow these steps to build and run the CLI:
 
-1. **Install dependencies**
+1. **Install dependencies** (required before running tests)
 
    ```bash
    npm install


### PR DESCRIPTION
## Summary
- add clarifying note in README about installing dependencies before tests
- mention `npm install` in CONTRIBUTING prior to test execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c81e9958832badc065de5482505b