### PR TITLE
Restrict identifiers to start with letters

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -43,7 +43,11 @@ function skipWS(str: string, i: number): number {
 }
 
 function parseIdentifier(str: string, i: number): { id: string; index: number } {
-  let start = i;
+  const start = i;
+  if (i >= str.length || !/[A-Za-z]/.test(str[i])) {
+    throw new Error('Expected identifier starting with a letter');
+  }
+  i++; // consume first letter
   while (i < str.length && /[A-Za-z0-9_%]/.test(str[i])) i++;
   return { id: str.slice(start, i), index: i };
 }

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -13,3 +13,43 @@ if (parsed.blocks[0].type !== 'meta' || parsed.blocks[0].props.tags[1] !== 'b') 
 }
 const out = serialize(parsed);
 parse(out); // should round trip without throwing
+
+let threw = false;
+try {
+  parse('@meta { 1abc: true; }');
+} catch (e) {
+  threw = true;
+}
+if (!threw) {
+  throw new Error('digits cannot start an identifier');
+}
+
+threw = false;
+try {
+  parse('@meta { _abc: true; }');
+} catch (e) {
+  threw = true;
+}
+if (!threw) {
+  throw new Error('underscores cannot start an identifier');
+}
+
+threw = false;
+try {
+  parse('@meta { foo: _bar; }');
+} catch (e) {
+  threw = true;
+}
+if (!threw) {
+  throw new Error('underscores cannot start identifier values');
+}
+
+threw = false;
+try {
+  parse('@meta { foo: 1bar; }');
+} catch (e) {
+  threw = true;
+}
+if (!threw) {
+  throw new Error('digits cannot start identifier values');
+}


### PR DESCRIPTION
## Summary
- ensure `parseIdentifier` enforces first-character letter requirement
- expand parser tests with cases for invalid identifiers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c8291420832bb99cc344b7cf1dec