### PR TITLE
Use parser workspace package

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,5 +8,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "node ../parser/tests/parser.test.ts"
+  },
+  "dependencies": {
+    "@osf/parser": "file:../parser"
   }
 }

--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { parse, serialize, OSFDocument, OSFBlock } from '../../parser/dist';
+import { parse, serialize, OSFDocument, OSFBlock } from '@osf/parser';
 
 function renderHtml(doc: OSFDocument): string {
   const parts: string[] = ['<html><body>'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
     "cli": {
       "name": "@osf/cli",
       "version": "0.1.0",
+      "dependencies": {
+        "@osf/parser": "file:../parser"
+      },
       "bin": {
         "osf": "bin/osf.js"
       }
@@ -67,6 +70,10 @@
     },
     "node_modules/@osf/cli": {
       "resolved": "cli",
+      "link": true
+    },
+    "node_modules/@osf/parser": {
+      "resolved": "parser",
       "link": true
     },
     "node_modules/@tsconfig/node10": {
@@ -245,6 +252,10 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "parser": {
+      "name": "@osf/parser",
+      "version": "0.1.0"
     }
   }
 }

--- a/parser/package.json
+++ b/parser/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@osf/parser",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1,4 +1,4 @@
-const { parse } = require('../parser/dist');
+const { parse } = require('@osf/parser');
 const { readFileSync } = require('fs');
 const input = readFileSync('./tests/fixtures/input.osf', 'utf8');
 const expected = JSON.parse(readFileSync('./tests/fixtures/expected_output.json', 'utf8'));


### PR DESCRIPTION
## Summary
- package `@osf/parser` as a workspace
- depend on parser package from CLI
- adjust import path in CLI sources
- update e2e test to use the package
- regenerate lockfile

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857c82ac17c832bb2f641be51a967a0