### PR TITLE
Fix unterminated block detection

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -14,6 +14,9 @@ function findBlocks(input: string): { type: string; content: string }[] {
       else if (ch === '}') depth--;
       end++;
     }
+    if (depth !== 0) {
+      throw new Error(`Unterminated block ${type} at ${match.index}`);
+    }
     const content = input.slice(match.index + match[0].length, end - 1);
     blocks.push({ type, content: content.trim() });
   }

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -13,3 +13,13 @@ if (parsed.blocks[0].type !== 'meta' || parsed.blocks[0].props.tags[1] !== 'b') 
 }
 const out = serialize(parsed);
 parse(out); // should round trip without throwing
+
+let errorCaught = false;
+try {
+  parse('@doc {\nmissing');
+} catch {
+  errorCaught = true;
+}
+if (!errorCaught) {
+  throw new Error('expected parse to throw for unterminated block');
+}


### PR DESCRIPTION
## Summary
- detect unterminated blocks in the parser
- add regression test for missing closing brace

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857c832d248832bb6048ff598ea2e85