### PR TITLE
Add export markdown CLI test

### DIFF
--- a/cli/tests/export.test.ts
+++ b/cli/tests/export.test.ts
@@ -1,0 +1,9 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const cli = require.resolve('../bin/osf.js');
+const file = path.resolve(__dirname, '../../examples/test_minimal.osf');
+
+const md = execFileSync('node', [cli, 'export', file], { encoding: 'utf8' });
+if (!md.includes('## Intro') && !md.includes('Hello World')) {
+  throw new Error('export output missing expected content');
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
     "pretest": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
-    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/error.test.ts"
+    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/export.test.ts && node cli/tests/error.test.ts"
   },
   "devDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- add `cli/tests/export.test.ts` covering `osf export`
- run this new test during `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c8347cf4832ba962aab1884d56f0