### PR TITLE
Add Markdown export support for meta and sheets

### DIFF
--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -61,6 +61,15 @@ function exportMarkdown(doc: OSFDocument): string {
   const out: string[] = [];
   for (const block of doc.blocks) {
     switch (block.type) {
+      case 'meta':
+        out.push('---');
+        for (const [k, v] of Object.entries((block as any).props)) {
+          if (typeof v === 'string') out.push(`${k}: ${v}`);
+          else out.push(`${k}: ${JSON.stringify(v)}`);
+        }
+        out.push('---');
+        out.push('');
+        break;
       case 'doc':
         out.push((block as any).content);
         break;
@@ -73,6 +82,36 @@ function exportMarkdown(doc: OSFDocument): string {
         }
         out.push('');
         break;
+      case 'sheet': {
+        const sheet = block as any;
+        if (sheet.cols) {
+          const cols = Array.isArray(sheet.cols)
+            ? sheet.cols
+            : String(sheet.cols)
+                .replace(/[\[\]]/g, '')
+                .split(',')
+                .map((s: string) => s.trim());
+          out.push('| ' + cols.join(' | ') + ' |');
+          out.push('|' + cols.map(() => '---').join('|') + '|');
+        }
+        if (sheet.data) {
+          const rows: Record<string, any> = sheet.data;
+          const coords = Object.keys(rows).map(k => k.split(',').map(Number));
+          const maxRow = Math.max(...coords.map(c => c[0]));
+          const maxCol = Math.max(...coords.map(c => c[1]));
+          for (let r = 1; r <= maxRow; r++) {
+            const cells: string[] = [];
+            for (let c = 1; c <= maxCol; c++) {
+              const key = `${r},${c}`;
+              const val = rows[key] ?? '';
+              cells.push(String(val));
+            }
+            out.push('| ' + cells.join(' | ') + ' |');
+          }
+        }
+        out.push('');
+        break;
+      }
     }
   }
   return out.join('\n');

--- a/cli/tests/export.test.ts
+++ b/cli/tests/export.test.ts
@@ -1,0 +1,10 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const cli = require.resolve('../bin/osf.js');
+const file = path.resolve(__dirname, '../../examples/test_minimal.osf');
+
+const out = execFileSync('node', [cli, 'export', file, '--target', 'md'], { encoding: 'utf8' });
+if (!out.includes('title: Demo') || !out.includes('Hello World') ||
+    !out.includes('## Intro') || !out.includes('| A | B |') || !out.includes('| 1 | 2 |')) {
+  throw new Error('markdown export failed');
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
     "pretest": "npx tsc -p parser/tsconfig.json && npx tsc -p cli/tsconfig.json",
-    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/error.test.ts"
+    "test": "npx ts-node parser/tests/parser.test.ts && node tests/e2e.test.js && node cli/tests/cli.test.ts && node cli/tests/lint.test.ts && node cli/tests/diff.test.ts && node cli/tests/export.test.ts && node cli/tests/error.test.ts"
   },
   "devDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- handle `meta` and `sheet` in Markdown exporter
- test CLI markdown export across all block types
- run new test in npm scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857c837d534832bae7a0ed02c3806af