### PR TITLE
Fix docs for released v0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,20 +191,15 @@ Join us on
 [GitHub Discussions](https://github.com/OmniScriptOSF/omniscript-core/discussions)
 to propose ideas, ask questions, or share feedback.
 
----
-
-## 🌐 Resources (coming soon)
-
-- Project website & docs
-- Interactive OSF viewer
-- Conversion tools
-- Example repository
-- Roadmap and specification drafts
-
----
 
 ## 💡 Vision
 
 OmniScript Format (OSF) aims to be the universal document source language — a
 single plain-text format powering documents, presentations, and data tables in a
 world of AI collaboration and versioned knowledge.
+
+## ❗ Known Limitations (v0.5)
+
+- The initial CLI only covers parsing, linting and basic rendering; advanced conversion targets are under development.
+- Diagram blocks, citation syntax and macro support are planned for future revisions.
+- Formal grammar and normative references are scheduled for a later appendix release.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,7 @@ This repository hosts the reference implementation of **OmniScript Format
 (OSF)**. The codebase is organised as a monorepo with separate packages for the
 parser and CLI.
 
-The `spec/` directory contains versioned specifications. The current draft is
-[spec/v0.5](../spec/v0.5/) which defines the grammar and JSON schema used by the
-parser.
+The `spec/` directory contains versioned specifications. The current release is [spec/v0.5](../spec/v0.5/) which defines the grammar and JSON schema used by the parser.
 
 ```
 omniscript-core/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,8 +2,7 @@
 
 We welcome pull requests!
 
-1. Read the OSF draft in [spec/v0.5](../spec/v0.5/) to understand the current
-   language features.
+1. Read the OSF v0.5 specification in [spec/v0.5](../spec/v0.5/) to understand the current language features.
 2. Follow the coding style used in the parser and CLI packages.
 3. Tests are located under `tests/` and `parser/tests`. Please add tests for new
    functionality.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -2,7 +2,7 @@
 
 This project follows the OSF v0.5 specification located under `spec/v0.5`. The
 core blocks – `@meta`, `@doc`, `@slide` and `@sheet` – are implemented as
-described in that draft.
+described in that release.
 
 - **Parser simplicity** – The reference parser mirrors the grammar in
   `spec/v0.5/grammar.ebnf` to keep implementations easy to understand.

--- a/docs/spec-v0.5-overview.md
+++ b/docs/spec-v0.5-overview.md
@@ -1,6 +1,6 @@
 # OSF v0.5 Overview
 
-This document summarises the key elements of the OmniScript Format v0.5 draft.
+This document summarises the key elements of the OmniScript Format v0.5 specification.
 Refer to the files under `spec/v0.5/` for the authoritative specification.
 
 ## Core Blocks

--- a/spec/v0.5/osf-spec.md
+++ b/spec/v0.5/osf-spec.md
@@ -1,4 +1,4 @@
-# OmniScript Format (OSF) – Specification Draft
+# OmniScript Format (OSF) – v0.5 Specification
 
 **OmniScript Format (OSF)** is a new domain-specific language (DSL) designed as
 _“the universal document DSL for LLMs, agentic AI, and Git-native workflows.”_
@@ -492,7 +492,7 @@ outlines the tooling and how users can work with OSF documents:
   features as they become necessary. For now, typical use (a few hundred pages
   or slides, moderate data) is easily handled by modern computers.
 
-The **implementation status**: At the time of this draft, the core parser and
+The **implementation status**: At the time of this release, the core parser and
 initial CLI commands are under development in the `omniscript-core` repository.
 Example OSF documents and tests are provided there to illustrate usage.
 Community contributions are welcome to expand the tooling (see **Contributing**
@@ -500,12 +500,12 @@ guidelines in the repository).
 
 ## Roadmap
 
-OSF is currently a draft specification and prototype. The roadmap below outlines
+OSF is currently an early-stage specification and prototype. The roadmap below outlines
 the path toward a stable 1.0 release and beyond, indicating both technical
 milestones and standardization efforts:
 
-- **v0.5 – Draft Specification & Prototype (2025):** The focus is on validating
-  the core ideas. Deliverables include this draft spec, the reference parser,
+- **v0.5 – Initial Specification & Prototype (2025):** The focus is on validating
+  the core ideas. Deliverables include this specification, the reference parser,
   and basic CLI functionality (parse, render to a couple of formats, basic
   lint). Feedback is solicited from early adopters, especially regarding the
   syntax choices and conversion fidelity.
@@ -592,7 +592,7 @@ robust and widely adopted.
 
 _The following appendices will provide detailed technical specifications and
 references in a future revision of this document. They are outlined here for
-completeness but are not yet included in this draft._
+completeness but are not yet included in this release._
 
 ### Appendix A: OSF Grammar Definition (BNF)
 


### PR DESCRIPTION
## Summary
- drop placeholder 'Resources' section
- note limitations of the current release
- update docs to reference the v0.5 specification
- remove 'draft' wording from the spec

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3ad9e814832b990f96bd3043f672