### PR TITLE
Fix parsing of negative numbers

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -78,6 +78,7 @@ function parseString(str: string, i: number): { value: string; index: number } {
 
 function parseNumber(str: string, i: number): { value: number; index: number } {
   let j = i;
+  if (str[j] === '-') j++; // handle optional negative sign
   while (j < str.length && /[0-9.]/.test(str[j]!)) j++;
   return { value: Number(str.slice(i, j)), index: j };
 }
@@ -107,7 +108,7 @@ function parseValue(str: string, i: number): { value: any; index: number } {
     const res = parseKVInternal(str, i + 1);
     return { value: res.obj, index: res.index + 1 };
   }
-  if (/\d/.test(ch)) return parseNumber(str, i);
+  if (ch === '-' || /\d/.test(ch)) return parseNumber(str, i);
   if (str.startsWith('true', i)) return { value: true, index: i + 4 };
   if (str.startsWith('false', i)) return { value: false, index: i + 5 };
   const id = parseIdentifier(str, i);

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -22,6 +22,13 @@ describe('OSF Parser', () => {
       expect(metaBlock.props.date).toBe('2025-01-01');
     });
 
+    it('should parse negative numbers', () => {
+      const input = `@meta { value: -42; }`;
+      const result = parse(input);
+      const metaBlock = result.blocks[0] as MetaBlock;
+      expect(metaBlock.props.value).toBe(-42);
+    });
+
     it('should parse a doc block', () => {
       const input = `@doc {
         # Test Document


### PR DESCRIPTION
## Summary
- support negative numeric literals in parser
- add a regression test for negative numbers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685da45bca14832bb5cf567f130f0e57