### PR TITLE
Import CLI version dynamically

### DIFF
--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from 'fs';
 import Ajv from 'ajv';
+import { version as cliVersion } from '../package.json';
 import {
   parse,
   serialize,
@@ -307,7 +308,7 @@ class FormulaEvaluator {
 }
 
 function showHelp(): void {
-  console.log('OmniScript Format (OSF) CLI v0.5.0');
+  console.log(`OmniScript Format (OSF) CLI v${cliVersion}`);
   console.log('Universal document DSL for LLMs and Git-native workflows\n');
   console.log('Usage: osf <command> [options]\n');
   console.log('Commands:');
@@ -328,7 +329,7 @@ function showHelp(): void {
 }
 
 function showVersion(): void {
-  console.log('0.5.0');
+  console.log(cliVersion);
 }
 
 function handleError(error: Error, context: string): never {

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
 import { writeFileSync, readFileSync, unlinkSync, existsSync } from 'fs';
 import { join } from 'path';
+import { version as cliVersion } from '../package.json';
 
 const CLI_PATH = join(__dirname, '../dist/osf.js');
 const TEST_FIXTURES_DIR = join(__dirname, 'fixtures');
@@ -106,7 +107,7 @@ describe('OSF CLI', () => {
     it('should show version when --version is passed', () => {
       const result = execSync(`node "${CLI_PATH}" --version`, { encoding: 'utf8' });
 
-      expect(result.trim()).toBe('0.5.0');
+      expect(result.trim()).toBe(cliVersion);
     });
 
     it('should show help when no arguments are passed', () => {


### PR DESCRIPTION
## Summary
- read the CLI version from `package.json`
- use the imported version in help and version output
- update CLI tests to expect the dynamic version

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685f297ea42c832ba3efb0fbca7e5016