### PR TITLE
Implement not implemented errors for render formats

### DIFF
--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -500,26 +500,22 @@ function renderHtml(doc: OSFDocument): string {
 // Basic stubs for additional formats
 function renderPdf(doc: OSFDocument): string {
   void doc; // placeholder usage
-  // TODO: real PDF rendering
-  return 'PDF rendering not implemented.';
+  throw new Error('PDF rendering not implemented');
 }
 
 function renderDocx(doc: OSFDocument): string {
   void doc;
-  // TODO: real DOCX rendering
-  return 'DOCX rendering not implemented.';
+  throw new Error('DOCX rendering not implemented');
 }
 
 function renderPptx(doc: OSFDocument): string {
   void doc;
-  // TODO: real PPTX rendering
-  return 'PPTX rendering not implemented.';
+  throw new Error('PPTX rendering not implemented');
 }
 
 function renderXlsx(doc: OSFDocument): string {
   void doc;
-  // TODO: real XLSX rendering
-  return 'XLSX rendering not implemented.';
+  throw new Error('XLSX rendering not implemented');
 }
 
 function exportMarkdown(doc: OSFDocument): string {

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -212,36 +212,52 @@ describe('OSF CLI', () => {
       }
     });
 
-    it('should render OSF to PDF', () => {
-      const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format pdf`, {
-        encoding: 'utf8',
-      });
-
-      expect(result).toContain('PDF rendering not implemented.');
+    it('should fail to render OSF to PDF', () => {
+      try {
+        const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format pdf`, {
+          encoding: 'utf8',
+        });
+        expect.fail(`Expected render command to fail but succeeded with output: ${result}`);
+      } catch (err: any) {
+        const output = (err.stderr || err.stdout) as string;
+        expect(output).toContain('PDF rendering not implemented');
+      }
     });
 
-    it('should render OSF to DOCX', () => {
-      const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format docx`, {
-        encoding: 'utf8',
-      });
-
-      expect(result).toContain('DOCX rendering not implemented.');
+    it('should fail to render OSF to DOCX', () => {
+      try {
+        const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format docx`, {
+          encoding: 'utf8',
+        });
+        expect.fail(`Expected render command to fail but succeeded with output: ${result}`);
+      } catch (err: any) {
+        const output = (err.stderr || err.stdout) as string;
+        expect(output).toContain('DOCX rendering not implemented');
+      }
     });
 
-    it('should render OSF to PPTX', () => {
-      const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format pptx`, {
-        encoding: 'utf8',
-      });
-
-      expect(result).toContain('PPTX rendering not implemented.');
+    it('should fail to render OSF to PPTX', () => {
+      try {
+        const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format pptx`, {
+          encoding: 'utf8',
+        });
+        expect.fail(`Expected render command to fail but succeeded with output: ${result}`);
+      } catch (err: any) {
+        const output = (err.stderr || err.stdout) as string;
+        expect(output).toContain('PPTX rendering not implemented');
+      }
     });
 
-    it('should render OSF to XLSX', () => {
-      const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format xlsx`, {
-        encoding: 'utf8',
-      });
-
-      expect(result).toContain('XLSX rendering not implemented.');
+    it('should fail to render OSF to XLSX', () => {
+      try {
+        const result = execSync(`node "${CLI_PATH}" render "${testFile}" --format xlsx`, {
+          encoding: 'utf8',
+        });
+        expect.fail(`Expected render command to fail but succeeded with output: ${result}`);
+      } catch (err: any) {
+        const output = (err.stderr || err.stdout) as string;
+        expect(output).toContain('XLSX rendering not implemented');
+      }
     });
 
     it('should render OSF to HTML file', () => {


### PR DESCRIPTION
## Summary
- throw explicit errors for PDF, DOCX, PPTX, and XLSX render functions
- update CLI tests for new failure behavior

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685f298d85a0832ba2ce4edf3489468c