### PR TITLE
Fix tsconfig mapping for parser types

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -20,6 +20,9 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
+    "paths": {
+      "omniscript-parser": ["../parser/dist"]
+    },
     "types": ["node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- map `omniscript-parser` to built parser in CLI tsconfig

## Testing
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685f299e0458832bae860120e7dad7ac