### PR TITLE
Enable schema validation and tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist/**/*",
     "bin/**/*",
+    "../spec/v0.5/osf.schema.json",
     "README.md",
     "LICENSE"
   ],

--- a/cli/src/osf.ts
+++ b/cli/src/osf.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import Ajv from 'ajv';
 import {
   parse,
@@ -79,11 +80,10 @@ const commands: CliCommand[] = [
   },
 ];
 
-// Schema validation temporarily disabled for package distribution
-// const schema = JSON.parse(readFileSync(join(__dirname, '../../spec/v0.5/osf.schema.json'), 'utf8'));
+const schema = JSON.parse(readFileSync(join(__dirname, '../../spec/v0.5/osf.schema.json'), 'utf8'));
 const ajv = new Ajv();
 ajv.addFormat('date', /^\d{4}-\d{2}-\d{2}$/);
-// const validateOsf = ajv.compile(schema);
+const validateOsf = ajv.compile(schema);
 
 // Formula evaluator for spreadsheet calculations
 class FormulaEvaluator {
@@ -801,14 +801,13 @@ function main(): void {
           console.log('⚠️  Warning: Document contains no blocks');
         }
 
-        // Schema validation temporarily disabled
-        // const obj = exportJson(doc);
-        // const parsed = JSON.parse(obj);
-        // if (!validateOsf(parsed)) {
-        //   console.error('❌ Lint failed: Schema validation errors');
-        //   console.error(ajv.errorsText(validateOsf.errors || undefined));
-        //   process.exit(1);
-        // }
+        const obj = exportJson(doc);
+        const parsed = JSON.parse(obj);
+        if (!validateOsf(parsed)) {
+          console.error('❌ Lint failed: Schema validation errors');
+          console.error(ajv.errorsText(validateOsf.errors || undefined));
+          process.exit(1);
+        }
 
         console.log('✅ Lint passed: Document syntax is valid');
         break;

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -153,6 +153,17 @@ describe('OSF CLI', () => {
         execSync(`node "${CLI_PATH}" lint "${invalidFile}"`, { encoding: 'utf8' });
       }).toThrow();
     });
+
+    it('should fail schema validation', () => {
+      const schemaFile = join(TEST_FIXTURES_DIR, 'missing_title.osf');
+      try {
+        execSync(`node "${CLI_PATH}" lint "${schemaFile}"`, { encoding: 'utf8' });
+        expect.fail('Expected schema validation to fail');
+      } catch (err: any) {
+        const output = `${err.stdout || ''}${err.stderr || ''}`;
+        expect(output).toContain('Schema validation');
+      }
+    });
   });
 
   describe('format command', () => {


### PR DESCRIPTION
## Summary
- include OSF schema in published package
- load and compile schema with Ajv
- enforce schema validation in `lint` command
- test lint failures when schema doesn't match

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f29ac2cbc832b8180e0f237af8379