### PR TITLE
fix: detect unterminated string literals in parser

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -129,6 +129,9 @@ function parseString(str: string, i: number): { value: string; index: number } {
       j++;
     }
   }
+  if (j >= str.length || str[j] !== '"') {
+    throw new Error('Unterminated string literal');
+  }
   return { value: out, index: j + 1 };
 }
 

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -51,6 +51,11 @@ describe('OSF Parser', () => {
       // Paragraph with link
       expect(slide.content?.[6].type).toBe('paragraph');
     });
+
+    it('should throw on unterminated string values', () => {
+      const input = '@meta {\n  title: "Unclosed;\n}';
+      expect(() => parse(input)).toThrow('Unterminated string literal');
+    });
   });
 
   describe('serialize', () => {


### PR DESCRIPTION
## Summary
- ensure parser throws on unterminated string literals
- cover unterminated string with unit test

## Testing
- `npm test`
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_688eb01dd4bc832b89b0ef2cabf3997b