### PR TITLE
feat(parser): add strikethrough support

### DIFF
--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -210,7 +210,7 @@ function parseKV(content: string): Record<string, OSFValue> {
 
 function parseStyledText(text: string): TextRun[] {
   const runs: TextRun[] = [];
-  const regex = /(\*\*.*?\*\*|__.*?__|\*.*?\*|!\[.*?\]\(.*?\)|\[.*?\]\(.*?\))/g;
+  const regex = /(\*\*.*?\*\*|__.*?__|\*.*?\*|~~.*?~~|!\[.*?\]\(.*?\)|\[.*?\]\(.*?\))/g;
   const parts = text.split(regex).filter(p => p);
 
   for (const part of parts) {
@@ -220,6 +220,8 @@ function parseStyledText(text: string): TextRun[] {
       runs.push({ text: part.slice(2, -2), underline: true });
     } else if (part.startsWith('*') && part.endsWith('*')) {
       runs.push({ text: part.slice(1, -1), italic: true });
+    } else if (part.startsWith('~~') && part.endsWith('~~')) {
+      runs.push({ text: part.slice(2, -2), strike: true });
     } else if (part.startsWith('![') && part.includes('](') && part.endsWith(')')) {
       const alt = part.slice(2, part.indexOf(']('));
       const url = part.slice(part.indexOf('](') + 2, -1);
@@ -588,6 +590,7 @@ function serializeTextRun(run: TextRun): string {
     if (styledText.bold) text = `**${text}**`;
     if (styledText.italic) text = `*${text}*`;
     if (styledText.underline) text = `__${text}__`;
+    if (styledText.strike) text = `~~${text}~~`;
     return text;
   }
   return '';

--- a/parser/src/types.ts
+++ b/parser/src/types.ts
@@ -15,6 +15,7 @@ export interface StyledText {
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;
+  strike?: boolean;
 }
 
 export type TextRun = string | StyledText | Link | Image;

--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -8,7 +8,7 @@ describe('OSF Parser', () => {
       const input =
         '@slide {\n' +
         '  title: "Comprehensive Slide";\n\n' +
-        '  This is a paragraph with **bold**, *italic*, and __underlined__ text.\n\n' +
+        '  This is a paragraph with **bold**, *italic*, __underlined__, and ~~struck through~~ text.\n\n' +
         '  - Unordered item 1\n' +
         '  - Unordered item 2\n\n' +
         '  1. Ordered item 1\n' +
@@ -50,6 +50,9 @@ describe('OSF Parser', () => {
 
       // Paragraph with link
       expect(slide.content?.[6].type).toBe('paragraph');
+
+      const paragraph = slide.content?.[0] as any;
+      expect(paragraph.content).toContainEqual({ text: 'struck through', strike: true });
     });
   });
 
@@ -64,13 +67,33 @@ describe('OSF Parser', () => {
               {
                 type: 'paragraph',
                 content: [
-                  { text: 'A paragraph with ', bold: false, italic: false, underline: false },
-                  { text: 'bold', bold: true, italic: false, underline: false },
-                  { text: ', ', bold: false, italic: false, underline: false },
-                  { text: 'italic', bold: false, italic: true, underline: false },
-                  { text: ', and ', bold: false, italic: false, underline: false },
-                  { text: 'underlined', bold: false, italic: false, underline: true },
-                  { text: ' text.', bold: false, italic: false, underline: false },
+                  {
+                    text: 'A paragraph with ',
+                    bold: false,
+                    italic: false,
+                    underline: false,
+                    strike: false,
+                  },
+                  { text: 'bold', bold: true, italic: false, underline: false, strike: false },
+                  { text: ', ', bold: false, italic: false, underline: false, strike: false },
+                  { text: 'italic', bold: false, italic: true, underline: false, strike: false },
+                  { text: ', ', bold: false, italic: false, underline: false, strike: false },
+                  {
+                    text: 'underlined',
+                    bold: false,
+                    italic: false,
+                    underline: true,
+                    strike: false,
+                  },
+                  { text: ', and ', bold: false, italic: false, underline: false, strike: false },
+                  {
+                    text: 'struck through',
+                    bold: false,
+                    italic: false,
+                    underline: false,
+                    strike: true,
+                  },
+                  { text: ' text.', bold: false, italic: false, underline: false, strike: false },
                 ],
               },
               {
@@ -115,7 +138,9 @@ describe('OSF Parser', () => {
       const result = serialize(doc);
 
       expect(result).toContain('@slide {\n  title: "Comprehensive Slide";');
-      expect(result).toContain('A paragraph with **bold**, *italic*, and __underlined__ text.');
+      expect(result).toContain(
+        'A paragraph with **bold**, *italic*, __underlined__, and ~~struck through~~ text.'
+      );
       expect(result).toContain('- Unordered item 1');
       expect(result).toContain('1. Ordered item 1');
       expect(result).toContain('> This is a blockquote.');
@@ -130,7 +155,7 @@ describe('OSF Parser', () => {
       const original =
         '@slide {\n' +
         '  title: "Round Trip Test";\n\n' +
-        '  A paragraph with **bold** and *italic*.\n\n' +
+        '  A paragraph with **bold**, *italic*, and ~~strike~~.\n\n' +
         '  - Item 1\n' +
         '  - Item 2\n\n' +
         '  1. First\n' +


### PR DESCRIPTION
## Summary
- support `strike` boolean flag for styled text
- parse `~~text~~` into `StyledText` with `strike` and serialize back with `~~`
- test strikethrough parsing, serialization, and round trip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895adb75334832ba83fcf646c2c369e