### PR TITLE
feat(parser): support unicode escapes

### DIFF
--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parse, serialize } from '../src/parser';
-import { OSFDocument, SlideBlock } from '../src/types';
+import { OSFDocument, SlideBlock, MetaBlock } from '../src/types';
 
 describe('OSF Parser', () => {
   describe('parse', () => {
@@ -148,6 +148,23 @@ describe('OSF Parser', () => {
       const parsed2 = parse(serialized);
 
       expect(JSON.stringify(parsed2)).toBe(JSON.stringify(parsed1));
+    });
+  });
+
+  describe('unicode escapes', () => {
+    it('parses unicode escape sequences', () => {
+      const input = '@meta {\n  title: "\\u03A9 and \\xE9";\n}';
+      const result = parse(input);
+      const meta = result.blocks[0] as MetaBlock;
+      expect(meta.props.title).toBe('Ω and é');
+    });
+
+    it('serializes unicode characters with escape sequences', () => {
+      const doc: OSFDocument = {
+        blocks: [{ type: 'meta', props: { title: 'Ω and é' } as any }],
+      };
+      const out = serialize(doc);
+      expect(out).toContain('title: "\\u03A9 and \\xE9";');
     });
   });
 });


### PR DESCRIPTION
## Summary
- handle `\uXXXX` and `\xXX` escapes in string parser
- escape non-ascii characters on serialization
- test Unicode escape parsing and serialization

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895adb91510832b9128c280b23a04e2