### PR TITLE
feat(parser): add position info to errors

### DIFF
--- a/parser/tests/parser.test.ts
+++ b/parser/tests/parser.test.ts
@@ -53,6 +53,23 @@ describe('OSF Parser', () => {
     });
   });
 
+  describe('error positions', () => {
+    it('should report line and column for syntax errors', () => {
+      const badInput = '@meta {\n  title "Missing colon";\n}';
+      expect(() => parse(badInput)).toThrowError(/Expected : at 2:9/);
+    });
+
+    it('should report line and column for unclosed blocks', () => {
+      const badInput = '@meta {\n  title: "Test";';
+      try {
+        parse(badInput);
+        throw new Error('Expected parse to fail');
+      } catch (e: any) {
+        expect(e.message).toMatch(/Missing closing \} for block meta at 2:17/);
+      }
+    });
+  });
+
   describe('serialize', () => {
     it('should serialize a slide with all content types', () => {
       const doc: OSFDocument = {


### PR DESCRIPTION
## Summary
- track line and column to pinpoint parsing errors
- include `line:column` details in thrown error messages
- test error paths for accurate position reporting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895adba0ed8832b822a4f4f6f902ab8